### PR TITLE
Simplify HashMap::get_mut

### DIFF
--- a/src/default_hashmap.rs
+++ b/src/default_hashmap.rs
@@ -110,26 +110,11 @@ where
     where
         K: Hash + Eq + Clone
     {
-        #[allow(unused_assignments)]
-        let mut rv: Option<&mut V> = Option::None;
-        let mut check: bool = false;
-        for _key in self._inner.keys() {
-            if key == _key {
-                check = true;
-            }
+        let exists = self._inner.keys().any(|k| key == k);
+        if !exists {
+            self.insert(key.clone(), V::default());
         }
-
-        match check {
-            true => {
-                rv = self._inner.get_mut(key);
-            },
-            false => {
-                self.insert(key.clone(), V::default());
-                rv = self._inner.get_mut(key);
-            },
-        };
-
-        rv.unwrap()
+        self._inner.get_mut(key).unwrap()
     }
 
 


### PR DESCRIPTION
Hello, @MitchellBerend!

I came across your library while searching for `defaultdict` analog in Rust. It looks exactly what I'm looking for, so this is my little contribution as an appreciation for your work. Also, consider to look at [`unwrap_at_default`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap_or_default), maybe it help you simplify code even more.