### PR TITLE
Minor version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defaultdict"
-version = "0.16.0"
+version = "0.16.1"
 description = "A hashmap implementation that mirrors the python defaultdict."
 edition = "2021"
 authors = ["Mitchell Berendhuysen"]


### PR DESCRIPTION
Bumped version in preparation for the minor update release of 0.16.1. This update only changes documentation, none of the internals or apis are changed.