### PR TITLE
Relax needless bounds

### DIFF
--- a/src/default_btree.rs
+++ b/src/default_btree.rs
@@ -739,7 +739,7 @@ where
 
 impl<'a, K, V> IntoIterator for &'a DefaultBTreeMap<K, V>
 where
-    K: Eq + Ord + Clone,
+    K: Eq + Ord,
     V: Default,
 {
     type Item = (&'a K, &'a V);
@@ -752,7 +752,7 @@ where
 
 impl<K, V> Index<&K> for DefaultBTreeMap<K, V>
 where
-    K: Eq + Ord + Clone,
+    K: Eq + Ord,
     V: Default,
 {
     type Output = V;
@@ -764,7 +764,7 @@ where
 
 impl<'a, K, V> IntoIterator for &'a mut DefaultBTreeMap<K, V>
 where
-    K: Eq + Ord + Clone,
+    K: Eq + Ord,
     V: Default,
 {
     type Item = (&'a K, &'a mut V);
@@ -777,7 +777,7 @@ where
 
 impl<K, V> From<BTreeMap<K, V>> for DefaultBTreeMap<K, V>
 where
-    K: Eq + Ord + Clone,
+    K: Eq + Ord,
     V: Default,
 {
     fn from(btree: BTreeMap<K, V>) -> Self {
@@ -790,7 +790,7 @@ where
 
 impl<K, V> From<DefaultBTreeMap<K, V>> for BTreeMap<K, V>
 where
-    K: Eq + Ord + Clone,
+    K: Eq + Ord,
     V: Default,
 {
     fn from(btree: DefaultBTreeMap<K, V>) -> Self {
@@ -800,7 +800,7 @@ where
 
 impl<K, V> Iterator for DefaultBTreeMapIter<K, V>
 where
-    K: Eq + Ord + Clone,
+    K: Eq + Ord,
     V: Default,
 {
     type Item = (K, V);

--- a/src/default_hashmap.rs
+++ b/src/default_hashmap.rs
@@ -575,7 +575,7 @@ where
 
 impl<K, V, S> IntoIterator for DefaultHashMap<K, V, S>
 where
-    K: Eq + Hash + Ord + Clone,
+    K: Eq + Hash + Clone,
     V: Default,
     S: BuildHasher,
 {
@@ -597,7 +597,7 @@ where
 
 impl<'a, K, V, S> IntoIterator for &'a DefaultHashMap<K, V, S>
 where
-    K: Eq + Hash + Ord + Clone,
+    K: Eq + Hash,
     V: Default,
     S: BuildHasher,
 {
@@ -611,7 +611,7 @@ where
 
 impl<K, V, S> Index<&K> for DefaultHashMap<K, V, S>
 where
-    K: Eq + Hash + Ord + Clone,
+    K: Eq + Hash,
     V: Default,
     S: BuildHasher,
 {
@@ -624,7 +624,7 @@ where
 
 impl<'a, K, V, S> IntoIterator for &'a mut DefaultHashMap<K, V, S>
 where
-    K: Eq + Hash + Ord + Clone,
+    K: Eq + Hash,
     V: Default,
     S: BuildHasher,
 {
@@ -638,7 +638,7 @@ where
 
 impl<K, V, S> From<HashMap<K, V, S>> for DefaultHashMap<K, V, S>
 where
-    K: Eq + Hash + Ord + Clone,
+    K: Eq + Hash,
     V: Default,
     S: BuildHasher,
 {
@@ -652,7 +652,7 @@ where
 
 impl<K, V, S> From<DefaultHashMap<K, V, S>> for HashMap<K, V, S>
 where
-    K: Eq + Hash + Ord + Clone,
+    K: Eq + Hash,
     V: Default,
     S: BuildHasher,
 {
@@ -663,7 +663,7 @@ where
 
 impl<K, V, S> Iterator for DefaultHashMapIter<K, V, S>
 where
-    K: Eq + Hash + Ord + Clone,
+    K: Eq + Hash,
     V: Default,
     S: BuildHasher,
 {
@@ -682,7 +682,7 @@ where
 
 pub struct DefaultHashMapIter<K, V, S>
 where
-    K: Eq + Hash + Ord,
+    K: Eq + Hash,
     V: Default,
     S: BuildHasher,
 {


### PR DESCRIPTION
All of the `Ord` bounds here are not needed, since there are no comparisons used.