### PR TITLE
Added `extract_if` and `get_disjoint_mut`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
       - name: cargo llvm-cov
         run: cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ubuntu / stable / cargo format
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run cargo fmt
       run: cargo fmt
 
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ubuntu / stable / cargo clippy
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run cargo clippy
       run: cargo clippy
 
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ubuntu / stable / cargo test
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo test --verbose
 
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ubuntu / stable / cargo test doc
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo test --doc --verbose
 
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ubuntu / stable / coverage
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install stable
@@ -63,6 +63,7 @@ jobs:
       - name: cargo llvm-cov
         run: cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,8 @@ jobs:
       - name: cargo llvm-cov
         run: cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          env_vars: OS,RUST

--- a/src/default_btree.rs
+++ b/src/default_btree.rs
@@ -798,7 +798,7 @@ where
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
         let mut map = DefaultBTreeMap::default();
         for (k, v) in iter {
-            let _ = map.insert(k, v);
+            map.insert(k, v);
         }
         map
     }


### PR DESCRIPTION
This pr adds 2 methods on `DefaultHashMap` to bring it up to rust version 1.88


Edit: This is blocked until the [image](https://github.com/actions/runner-images) used in ci cuts a new release that includes rust 1.88, It is stuck on 1.87 now. 